### PR TITLE
Containerize crawler

### DIFF
--- a/crawler-project/Dockerfile
+++ b/crawler-project/Dockerfile
@@ -1,0 +1,33 @@
+FROM continuumio/miniconda3
+
+WORKDIR /usr/src/app
+
+COPY scrapy.cfg .
+COPY requirements.txt .
+COPY crawler crawler
+
+# install build dependencies
+RUN apt-get update && \
+    apt-get install -y \
+    g++ \
+    make \
+    cmake \
+    unzip \
+    libcurl4-openssl-dev
+
+# create Conda environment
+RUN conda create -n crawler python=3.10
+
+# make RUN commands use the new environment
+RUN echo "conda activate crawler" >> ~/.bashrc
+SHELL ["/bin/bash", "--login", "-c"]
+
+RUN pip install -r requirements.txt
+
+COPY entrypoint.sh .
+
+RUN chmod +x entrypoint.sh
+
+ENTRYPOINT ["./entrypoint.sh"]
+
+CMD ["sh", "-c", "python3 ./crawler/scripts/crawl.py"]

--- a/crawler-project/crawler/scripts/crawl.py
+++ b/crawler-project/crawler/scripts/crawl.py
@@ -1,0 +1,15 @@
+from twisted.internet import reactor
+from scrapy.crawler import CrawlerRunner
+from scrapy.utils.project import get_project_settings
+from scrapy.utils.log import configure_logging
+from crawler.spiders.ft import FtSpider
+
+configure_logging({"LOG_FORMAT": "%(levelname)s: %(message)s"})
+
+settings = get_project_settings()
+
+runner = CrawlerRunner(settings)
+
+d = runner.crawl(FtSpider)
+d.addBoth(lambda _: reactor.stop())
+reactor.run()

--- a/crawler-project/entrypoint.sh
+++ b/crawler-project/entrypoint.sh
@@ -1,0 +1,21 @@
+#!/bin/bash --login
+# --login ensures bash configuration is loaded,
+# enabling Conda.
+
+# enable discovery of Scrapy config file
+export PYTHONPATH="/usr/src/app:$PYTHONPATH"
+
+# enable strict mode
+set -euo pipefail
+
+# temporarily disable strict mode
+set +euo pipefail
+
+# activate Conda environment
+conda activate crawler
+
+# re-enable strict mode
+set -euo pipefail
+
+# execute commands
+exec "$@"


### PR DESCRIPTION
# Description

This PR adds the Dockerfile and entrypoint Bash script required to containerize the crawler application. A future PR will add the ability to deploy the Docker image to Amazon ECS and run the container using AWS Fargate.

## Added

- Dockerfile
- entrypoint Bash script
- Python script for running crawler
