### PR TITLE
Deploy crawler

### DIFF
--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -10,7 +10,12 @@ dotenv.config();
 
 const app = new cdk.App();
 new VPCStack(app, 'VPCStack');
-new CrawlerStack(app, 'CrawlerStack');
+new CrawlerStack(app, 'CrawlerStack', {
+    env: {
+        account: process.env.AWS_ACCOUNT_ID,
+        region: 'eu-west-1'
+    }
+});
 new DocDBStack(app, 'DocDBStack', {
     env: {
         account: process.env.AWS_ACCOUNT_ID,

--- a/cdk/test/crawler.test.ts
+++ b/cdk/test/crawler.test.ts
@@ -1,6 +1,9 @@
 import * as cdk from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';
 import * as Cdk from '../lib/crawler-stack';
+import * as dotenv from 'dotenv';
+
+dotenv.config();
 
 describe('Stack Created', () => {
     const app = new cdk.App();
@@ -21,10 +24,6 @@ describe('Stack Created', () => {
     });
 
     test('API Created', () => {
-        const app = new cdk.App();
-        const stack = new Cdk.CrawlerStack(app, 'TestStack');
-        const template = Template.fromStack(stack);
-
         template.hasResourceProperties('AWS::ApiGateway::Resource', {
             PathPart: 'ft'
         });
@@ -47,6 +46,19 @@ describe('Stack Created', () => {
                     }
                 ]
             }
+        });
+    });
+
+    test('Fargate Task Definition Created', () => {
+        template.hasResourceProperties('AWS::ECS::TaskDefinition', {
+            ContainerDefinitions: [
+                {
+                    Essential: true,
+                    Name: 'container-ft'
+                }
+            ],
+            Cpu: '512',
+            Memory: '1024'
         });
     });
 });

--- a/crawler-project/.gitignore
+++ b/crawler-project/.gitignore
@@ -1,4 +1,4 @@
-.env
+*.env
 crawls/
 **/__pycache__/
 **/.DS_STORE

--- a/crawler-project/Dockerfile
+++ b/crawler-project/Dockerfile
@@ -2,10 +2,6 @@ FROM continuumio/miniconda3
 
 WORKDIR /usr/src/app
 
-COPY scrapy.cfg .
-COPY requirements.txt .
-COPY crawler crawler
-
 # install build dependencies
 RUN apt-get update && \
     apt-get install -y \
@@ -22,10 +18,17 @@ RUN conda create -n crawler python=3.10
 RUN echo "conda activate crawler" >> ~/.bashrc
 SHELL ["/bin/bash", "--login", "-c"]
 
+# install Python dependencies
+COPY requirements.txt .
 RUN pip install -r requirements.txt
 
-COPY entrypoint.sh .
+# download CA certificate for TLS connection to DB
+RUN wget https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem
 
+COPY scrapy.cfg .
+COPY crawler crawler
+
+COPY entrypoint.sh .
 RUN chmod +x entrypoint.sh
 
 ENTRYPOINT ["./entrypoint.sh"]

--- a/crawler-project/crawler/log_formatter.py
+++ b/crawler-project/crawler/log_formatter.py
@@ -1,0 +1,11 @@
+from scrapy import logformatter
+import logging
+
+
+class QuietLogFormatter(logformatter.LogFormatter):
+    def scraped(self, item, response, spider):
+        return (
+            super().scraped(item, response, spider)
+            if spider.settings.getbool("LOG_SCRAPED_ITEMS")
+            else None
+        )

--- a/crawler-project/crawler/scripts/crawl.py
+++ b/crawler-project/crawler/scripts/crawl.py
@@ -1,8 +1,13 @@
+import argparse
 from twisted.internet import reactor
 from scrapy.crawler import CrawlerRunner
 from scrapy.utils.project import get_project_settings
 from scrapy.utils.log import configure_logging
 from crawler.spiders.ft import FtSpider
+
+arg_parser = argparse.ArgumentParser()
+arg_parser.add_argument("year", type=int, nargs="?", default=None)
+args = arg_parser.parse_args()
 
 configure_logging({"LOG_FORMAT": "%(levelname)s: %(message)s"})
 
@@ -10,6 +15,6 @@ settings = get_project_settings()
 
 runner = CrawlerRunner(settings)
 
-d = runner.crawl(FtSpider)
+d = runner.crawl(FtSpider, year=args.year)
 d.addBoth(lambda _: reactor.stop())
 reactor.run()

--- a/crawler-project/crawler/settings.py
+++ b/crawler-project/crawler/settings.py
@@ -86,3 +86,7 @@ ITEM_PIPELINES = {
 # HTTPCACHE_DIR = 'httpcache'
 # HTTPCACHE_IGNORE_HTTP_CODES = []
 # HTTPCACHE_STORAGE = 'scrapy.extensions.httpcache.FilesystemCacheStorage'
+
+# Configure logging
+LOG_FORMATTER = "crawler.log_formatter.QuietLogFormatter"
+LOG_SCRAPED_ITEMS = False

--- a/crawler-project/crawler/spiders/ft.py
+++ b/crawler-project/crawler/spiders/ft.py
@@ -17,6 +17,11 @@ class FtSpider(SitemapSpider):
     name = "ft"
     allowed_domains = ["ft.com"]
     sitemap_urls = ["https://www.ft.com/sitemaps/index.xml"]
+    year: int | None
+
+    def __init__(self, year: int | None = None, *args, **kwargs):
+        super(FtSpider, self).__init__(*args, **kwargs)
+        self.year = year
 
     def start_requests(self):
         """Perform login by invoking Lambda function via API."""
@@ -54,7 +59,7 @@ class FtSpider(SitemapSpider):
             if entry["loc"].endswith("news.xml"):
                 continue
             date_time = dateutil.parser.parse(entry["lastmod"])
-            if date_time.year < 2012:
+            if date_time.year != self.year:
                 continue
             yield entry
 


### PR DESCRIPTION
# Description

This PR adds to the CDK application code the constructs necessary for provisioning an Amazon ECS cluster and AWS Fargate task definition for running the containerized crawler application, and parameterizes the threshold for filtering sitemap entries by `lastmod` attribute in the `ft` spider.

## Modified

- constructs added to `CrawlerStack` for provisioning ECS cluster and Fargate task definition
- threshold for filtering sitemap entries by `lastmod` attribute parameterized in `ft` spider
- CA certificate for establishing TLS connection to DocumentDB cluster added to Docker image
