### PR TITLE
Add price spider

### DIFF
--- a/crawler-project/crawler/items.py
+++ b/crawler-project/crawler/items.py
@@ -19,7 +19,8 @@ class ArticleItem(scrapy.Item):
     corp = scrapy.Field()
     symbol = scrapy.Field()
     exchange = scrapy.Field()
-    price = scrapy.Field()
+    prices = scrapy.Field()
+    vectorized = scrapy.Field()
 
 
 class SymbolItem(scrapy.Item):

--- a/crawler-project/crawler/pipelines/price_pipeline.py
+++ b/crawler-project/crawler/pipelines/price_pipeline.py
@@ -1,0 +1,15 @@
+import os
+from pymongo import MongoClient
+from pymongo.database import Database
+
+db: Database = MongoClient(os.environ["MONGODB_CONNECTION_URI"]).get_default_database()
+
+
+class PricePipeline:
+    def process_item(self, item, spider):
+        print(item)
+        db.articles.update_one(
+            {"_id": item["_id"]},
+            {"$set": item},
+        )
+        return item

--- a/crawler-project/crawler/spiders/price.py
+++ b/crawler-project/crawler/spiders/price.py
@@ -1,0 +1,99 @@
+import os
+from datetime import datetime, timedelta
+from urllib.parse import urlunsplit, urlencode
+import scrapy
+from scrapy import Request
+from dotenv import load_dotenv
+from pymongo import MongoClient
+from pymongo.database import Database
+from crawler.items import ArticleItem
+
+load_dotenv()
+
+EODHD_API_TOKEN = os.environ["EODHD_API_TOKEN"]
+db: Database = MongoClient(os.environ["MONGODB_CONNECTION_URI"]).get_default_database()
+
+
+class PriceSpider(scrapy.Spider):
+    name = "price"
+    from_: datetime | None
+    custom_settings = {
+        "ITEM_PIPELINES": {"crawler.pipelines.price_pipeline.PricePipeline": 543},
+        "CONCURRENT_REQUESTS": 3
+    }
+
+    def __init__(self, from_: str | None = None, *args, **kwargs):
+        super(PriceSpider, self).__init__(*args, **kwargs)
+        self.from_ = (
+            datetime.strptime(from_, "%Y-%m-%d")
+            if from_ is not None
+            else datetime.now()
+        )
+
+    def start_requests(self):
+        articles = (
+            ArticleItem(**article)
+            for article in db.articles.find(
+                {
+                    "symbol": {"$exists": True},
+                    "date_published": {"$gt": self.from_},
+                    "prices": {"$exists": False},
+                }
+            )
+        )
+
+        exchanges = {
+            "NYSE": "US",
+            "NASDAQ": "US",
+            "BATS": "US",
+            "OTCQB": "US",
+            "PINK": "US",
+            "OTCQX": "US",
+            "OTCMKTS": "US",
+            "NMFQS": "US",
+            "NYSE MKT": "US",
+            "OTCBB": "US",
+            "OTCGREY": "US",
+            "BATS": "US",
+            "OTC": "US",
+        }
+
+        for article in articles:
+            yield Request(
+                eodhd_api_url(
+                    "eod",
+                    article["symbol"]
+                    + "."
+                    + exchanges.get(article["exchange"], article["exchange"]),
+                    **{
+                        "from": article["date_published"].strftime("%Y-%m-%d"),
+                        "to": (article["date_published"] + timedelta(weeks=4)).strftime(
+                            "%Y-%m-%d"
+                        ),
+                    }
+                ),
+                errback=self.errback,
+                cb_kwargs={"article": article},
+            )
+
+    def parse(self, response, article: ArticleItem):
+        prices = response.json()
+        article["prices"] = None if not len(prices) else prices
+        yield article
+
+    def errback(self, failure):
+        article = failure.request.cb_kwargs["article"]
+        article["prices"] = None
+        yield article
+
+
+def eodhd_api_url(api_slug: str, *path_params, **query_params) -> str:
+    return urlunsplit(
+        (
+            "https",
+            "eodhistoricaldata.com",
+            os.path.join("api", api_slug, *path_params),
+            urlencode(dict(fmt="json", api_token=EODHD_API_TOKEN, **query_params)),
+            "",
+        )
+    )


### PR DESCRIPTION
# Description

This PR adds a Scrapy spider for fetching the stock prices of companies mentioned in news articles by consuming the [EOD Historical Data API](https://eodhistoricaldata.com/). Prices are fetched for a period of four weeks from the date of publication of each article.

## Added

- Scrapy spider code for ingesting stock prices
- Scrapy item pipeline for persisting prices to database

## Modified

- `ArticleItem` class definition updated
