### PR TITLE
Add vectorization job

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ This project uses the [pytest](https://docs.pytest.org/en/7.1.x/) software testi
  ┃ ┃ ┣ 📂facebook_bart_large_cnn
  ┃ ┃ ┗ 📂sentence_detector_dl_xx
  ┣ 📂config
+ ┣ 📂data
  ┣ 📂inference
  ┃ ┣ 📂services
  ┃ ┃ ┣ 📜logger.py

--- a/ml-pipeline/.gitignore
+++ b/ml-pipeline/.gitignore
@@ -2,5 +2,6 @@
 .pytest_cache
 artifacts
 assets
+data
 **/__pycache__/
 **/.DS_STORE

--- a/ml-pipeline/assets.Dockerfile
+++ b/ml-pipeline/assets.Dockerfile
@@ -18,6 +18,13 @@ RUN unzip \
     bert_large_token_classifier_conll03_en_3.2.0_2.4_1628171471927.zip \
     -d models/bert_large_token_classifier_conll03_en
 
+RUN wget \
+    https://s3.amazonaws.com/auxdata.johnsnowlabs.com/public/models/sent_bert_large_cased_en_2.6.0_2.4_1598346401930.zip
+
+RUN unzip \
+    sent_bert_large_cased_en_2.6.0_2.4_1598346401930 \
+    -d models/sent_bert_large_cased_en
+
 FROM python:3.10 as download_transformers_models
 
 RUN pip install transformers[torch]

--- a/ml-pipeline/inference/transformers/vectorizer.py
+++ b/ml-pipeline/inference/transformers/vectorizer.py
@@ -1,0 +1,128 @@
+import os
+from pyspark import keyword_only
+from pyspark.ml import Transformer
+from pyspark.ml.param.shared import (
+    HasInputCol,
+    HasOutputCol,
+    Param,
+    Params,
+    TypeConverters,
+)
+from pyspark.ml.util import DefaultParamsReadable, DefaultParamsWritable
+from pyspark.sql import DataFrame
+from pyspark.ml import Pipeline
+from sparknlp.base import DocumentAssembler
+from sparknlp.annotator import BertSentenceEmbeddings
+from sparknlp.base import EmbeddingsFinisher
+
+
+class Vectorizer(
+    Transformer,
+    HasInputCol,
+    HasOutputCol,
+    DefaultParamsReadable,
+    DefaultParamsWritable,
+):
+    cleanAnnotations = Param(
+        Params._dummy(),
+        "cleanAnnotations",
+        "Whether to remove annotation columns.",
+        typeConverter=TypeConverters.toBoolean,
+    )
+
+    emrfsModelPath = Param(
+        Params._dummy(),
+        "emrfsModelPath",
+        "The location, in URI format, of the Spark NLP model parent folder.",
+        typeConverter=TypeConverters.toString,
+    )
+
+    @keyword_only
+    def __init__(
+        self, inputCol=None, outputCol=None, cleanAnnotations=None, emrfsModelPath=None
+    ):
+        super().__init__()
+        self._setDefault(
+            inputCol="input",
+            outputCol="output",
+            cleanAnnotations=True,
+            emrfsModelPath=None,
+        )
+        kwargs = self._input_kwargs
+        self.setParams(**kwargs)
+
+    @keyword_only
+    def setParams(
+        self, inputCol=None, outputCol=None, cleanAnnotations=None, emrfsModelPath=None
+    ):
+        kwargs = self._input_kwargs
+        return self._set(**kwargs)
+
+    def setInputCol(self, inputCol):
+        return self.setParams(inputCol=inputCol)
+
+    def setOutputCol(self, outputCol):
+        return self.setParams(outputCol=outputCol)
+
+    def setCleanAnnotations(self, cleanAnnotations):
+        return self.setParams(cleanAnnotations=cleanAnnotations)
+
+    def setEmrfsModelPath(self, emrfsModelPath):
+        return self.setParams(emrfsModelPath=emrfsModelPath)
+
+    def getInputCol(self):
+        return self.getOrDefault(self.inputCol)
+
+    def getOutputCol(self):
+        return self.getOrDefault(self.outputCol)
+
+    def getCleanAnnotations(self):
+        return self.getOrDefault(self.cleanAnnotations)
+
+    def getModelUri(self, model_name):
+        emrfs_model_path = self.getOrDefault(self.emrfsModelPath)
+        if not emrfs_model_path:
+            return os.path.join("assets/models", model_name)
+        return os.path.join(emrfs_model_path, model_name)
+
+    def _transform(self, df: DataFrame) -> DataFrame:
+        document_assembler = (
+            DocumentAssembler().setInputCol(self.getInputCol()).setOutputCol("document")
+        )
+
+        sent_bert = (
+            BertSentenceEmbeddings.load(self.getModelUri("sent_bert_large_cased_en"))
+            .setInputCols("document")
+            .setOutputCol("sentence_embeddings")
+        )
+
+        embeddings_finisher = (
+            EmbeddingsFinisher()
+            .setInputCols("sentence_embeddings")
+            .setOutputCols("embeddings")
+            .setOutputAsVector(True)
+        )
+
+        df = (
+            Pipeline(
+                stages=[
+                    document_assembler,
+                    sent_bert,
+                    embeddings_finisher,
+                ]
+            )
+            .fit(df)
+            .transform(df)
+        )
+
+        return (
+            df.drop(
+                *(
+                    c
+                    for c in ["document", "sentence_embeddings"]
+                    if c != self.getOutputCol()
+                )
+            )
+            if self.getCleanAnnotations()
+            else df
+        )

--- a/ml-pipeline/jobs/vectorization.py
+++ b/ml-pipeline/jobs/vectorization.py
@@ -1,0 +1,129 @@
+import json, os
+from argparse import ArgumentParser
+from pyspark.ml import PipelineModel
+from pyspark.sql import SparkSession
+from pyspark.sql import DataFrame
+from pyspark.sql.types import (
+    StructType,
+    StructField,
+    StringType,
+    ArrayType,
+    DoubleType,
+    IntegerType,
+)
+from pyspark.sql.functions import col, lit, concat
+from inference.services.spark import start_spark
+from inference.transformers.vectorizer import Vectorizer
+
+parser = ArgumentParser()
+parser.add_argument("--data-dest-path", default="data")
+
+
+def main():
+    args = parser.parse_args()
+
+    spark, logger, config = start_spark()
+
+    df = _extract(spark)
+
+    df = _transform(df)
+
+    _load(df, args.data_dest_path)
+
+    spark.stop()
+
+
+def _extract(spark: SparkSession) -> DataFrame:
+    return (
+        spark.read.schema(
+            StructType(
+                [
+                    StructField(
+                        "_id",
+                        StructType([StructField("oid", StringType(), False)]),
+                        False,
+                    ),
+                    StructField("headline", StringType(), False),
+                    StructField("description", StringType(), False),
+                    StructField("summary", StringType(), False),
+                    StructField(
+                        "prices",
+                        ArrayType(
+                            StructType(
+                                [
+                                    StructField("date", StringType(), False),
+                                    StructField("open", DoubleType(), False),
+                                    StructField("high", DoubleType(), False),
+                                    StructField("low", DoubleType(), False),
+                                    StructField("close", DoubleType(), False),
+                                    StructField("adjusted_close", DoubleType(), False),
+                                    StructField("volume", IntegerType(), False),
+                                ]
+                            ),
+                            False,
+                        ),
+                        False,
+                    ),
+                ]
+            )
+        )
+        .format("mongo")
+        .option("collection", "articles")
+        .option(
+            "pipeline",
+            json.dumps(
+                [
+                    {
+                        "$match": {
+                            "prices": {"$ne": None},
+                            "vectorized": {"$exists": False},
+                        },
+                    },
+                    {
+                        "$project": {
+                            "headline": 1,
+                            "description": 1,
+                            "summary": 1,
+                            "prices": 1,
+                        }
+                    },
+                ]
+            ),
+        )
+        .load()
+    )
+
+
+def _transform(df: DataFrame) -> DataFrame:
+    return PipelineModel(
+        stages=[Vectorizer(inputCol="text", outputCol="embeddings")]
+    ).transform(
+        df.withColumn(
+            "text",
+            concat(
+                col("headline"),
+                lit(". "),
+                col("description"),
+                lit(". "),
+                col("summary"),
+            ),
+        )
+    )
+
+
+def _load(df: DataFrame, path_: str):
+    df.write.mode("append").parquet(os.path.join(path_, "embeddings"))
+
+    (
+        df.drop("embeddings")
+        .withColumn("vectorized", lit(True))
+        .write.format("mongo")
+        .mode("append")
+        .option("collection", "articles")
+        .option("replaceDocument", "false")
+        .save()
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/ml-pipeline/scripts/download_models.py
+++ b/ml-pipeline/scripts/download_models.py
@@ -1,7 +1,4 @@
-from transformers import (
-    BartForConditionalGeneration,
-    BartTokenizer,
-)
+from transformers import BartTokenizer, BartForConditionalGeneration
 
-BartForConditionalGeneration.from_pretrained("facebook/bart-large-cnn")
 BartTokenizer.from_pretrained("facebook/bart-large-cnn")
+BartForConditionalGeneration.from_pretrained("facebook/bart-large-cnn")

--- a/ml-pipeline/tests/vectorization_test.py
+++ b/ml-pipeline/tests/vectorization_test.py
@@ -1,0 +1,20 @@
+from inference.transformers.vectorizer import Vectorizer
+from pyspark.ml import PipelineModel
+from pyspark.sql.types import StructField, ArrayType
+from pyspark.ml.linalg import VectorUDT
+
+
+class TestVectorization:
+    def test_texts_vectorized(self, spark, article):
+        df = spark.createDataFrame([{"input": article}])
+
+        df = PipelineModel(stages=[Vectorizer(cleanAnnotations=False)]).transform(df)
+
+        df.show()
+
+        row = df.first()
+        assert row is not None
+        assert (
+            StructField("embeddings", ArrayType(VectorUDT(), True), True)
+            in df.schema.fields
+        )


### PR DESCRIPTION
# Description

Adds a Spark job for generating document embeddings for article texts using a [BERT](https://github.com/kweonwooj/papers/issues/114) model.

## Added

- custom [Transformer](https://spark.apache.org/docs/latest/ml-pipeline.html#transformers) for generating document embeddings
- ETL job for vectorizing article texts and writing vectors to Parquet file
- test covering generation of document embeddings

## Modified

- instructions for fetching model files added to `assets.Dockerfile` file
- vectorization task added to DAG for starting EMR Serverless job runs
